### PR TITLE
TrueTrace as a git submodule

### DIFF
--- a/LICENSE.txt.meta
+++ b/LICENSE.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 85b621a13426d6b4a92dfe25ec6834da
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md.meta
+++ b/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1c4943560d8d3ff48808bb631268814f
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace.meta
+++ b/TrueTrace.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 41cc122af0b9712459e5c6820e2aa9b9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace.unitypackage.meta
+++ b/TrueTrace.unitypackage.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0e89ab6b3d223164e8c888601e5d8cf1
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Bindless.meta
+++ b/TrueTrace/Bindless.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1ef66016b839d7f478c1863a76772d4f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Bindless/BindlessPlugin.cs.meta
+++ b/TrueTrace/Bindless/BindlessPlugin.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0505c8bcab3668448981370815c95b5f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Bindless/Plugins.meta
+++ b/TrueTrace/Bindless/Plugins.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 38a898b9a484208419d87cdd9c91c81b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Bindless/Plugins/x64.meta
+++ b/TrueTrace/Bindless/Plugins/x64.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f54cf485a08b5d846b629c52173109e4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Bindless/Plugins/x64/GfxPluginMeetemBindless.dll.meta
+++ b/TrueTrace/Bindless/Plugins/x64/GfxPluginMeetemBindless.dll.meta
@@ -1,0 +1,52 @@
+fileFormatVersion: 2
+guid: f9cf47bea856a8b47910176c49a2209d
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 1
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        CPU: x86_64
+        DefaultValueInitialized: true
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/DemoScene.asset.meta
+++ b/TrueTrace/DemoScene.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5bcb46872a4839344828e898b382a386
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/DemoScene.unity.meta
+++ b/TrueTrace/DemoScene.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2695fa74c49a8614f8480de586aba393
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Editor.meta
+++ b/TrueTrace/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 084c16dbff773384496de4674acaf95e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Editor/HierarchyModifers.cs.meta
+++ b/TrueTrace/Editor/HierarchyModifers.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 564b2d56c754fbd4b997c7d86533bc7e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Editor/MasterMaterialEditor.cs
+++ b/TrueTrace/Editor/MasterMaterialEditor.cs
@@ -93,7 +93,8 @@ using System.Xml.Serialization;
                 if(CopyIndex != -1) PresetRays.RayObj[CopyIndex] = TempRay;
                 else PresetRays.RayObj.Add(TempRay);
 
-                using(StreamWriter writer = new StreamWriter(Application.dataPath + "/TrueTrace/Resources/Utility/MaterialPresets.xml")) {
+                var materialPresetsPath = PathFinder.GetMaterialPresetsPath();
+                using(StreamWriter writer = new StreamWriter(materialPresetsPath)) {
                     var serializer = new XmlSerializer(typeof(RayObjs));
                     serializer.Serialize(writer.BaseStream, PresetRays);
                     UnityEditor.AssetDatabase.Refresh();
@@ -135,7 +136,8 @@ using System.Xml.Serialization;
                     if(GUILayout.Button(PresetRays.RayObj[i].MatName)) {CallEditorFunction(PresetRays.RayObj[i]); this.editorWindow.Close();}
                     if(GUILayout.Button("Delete")) {
                         PresetRays.RayObj.RemoveAt(i);
-                        using(StreamWriter writer = new StreamWriter(Application.dataPath + "/TrueTrace/Resources/Utility/MaterialPresets.xml")) {
+                        var materialPresetsPath = PathFinder.GetMaterialPresetsPath();
+                        using(StreamWriter writer = new StreamWriter(materialPresetsPath)) {
                             var serializer = new XmlSerializer(typeof(RayObjs));
                             serializer.Serialize(writer.BaseStream, PresetRays);
                             UnityEditor.AssetDatabase.Refresh();

--- a/TrueTrace/Editor/MasterMaterialEditor.cs.meta
+++ b/TrueTrace/Editor/MasterMaterialEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 53f86f9f9fd7ced498b992234aba17c2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Editor/ParentObjectEditor.cs.meta
+++ b/TrueTrace/Editor/ParentObjectEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 293b1565cba596a4e9cb8a51740f2e15
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Editor/PathTracerSettings.cs
+++ b/TrueTrace/Editor/PathTracerSettings.cs
@@ -103,9 +103,12 @@ namespace TrueTrace {
          [SerializeField] public bool UseTransmittanceInNEE = true;
 
 
-         public void SetGlobalDefines(string DefineToSet, bool SetValue) {
-            if(File.Exists(Application.dataPath + "/TrueTrace/Resources/GlobalDefines.cginc")) {
-               string[] GlobalDefines = System.IO.File.ReadAllLines(Application.dataPath + "/TrueTrace/Resources/GlobalDefines.cginc");
+         public void SetGlobalDefines(string DefineToSet, bool SetValue)
+         {
+            var globalDefinesPath = PathFinder.GetGlobalDefinesPath();
+            Debug.Log(globalDefinesPath);
+            if(File.Exists(globalDefinesPath)) {
+               string[] GlobalDefines = System.IO.File.ReadAllLines(globalDefinesPath);
                int Index = -1;
                for(int i = 0; i < GlobalDefines.Length; i++) {
                   if(GlobalDefines[i].Equals("//END OF DEFINES")) break;
@@ -126,7 +129,7 @@ namespace TrueTrace {
                   GlobalDefines[Index] = GlobalDefines[Index].Replace("// ", "");
                   if(!SetValue) GlobalDefines[Index] = "// " + GlobalDefines[Index];
 
-                  System.IO.File.WriteAllLines(Application.dataPath + "/TrueTrace/Resources/GlobalDefines.cginc", GlobalDefines);
+                  System.IO.File.WriteAllLines(globalDefinesPath, GlobalDefines);
                   AssetDatabase.Refresh();
                }
             } else {Debug.Log("No GlobalDefinesFile");}
@@ -991,7 +994,8 @@ Toolbar toolbar;
          MatShader.IsCutout = CutoutToggle.value;
          MatShader.UsesSmoothness = SmoothnessToggle.value;
          AssetManager.data.Material[Index] = MatShader;
-         using(StreamWriter writer = new StreamWriter(Application.dataPath + "/TrueTrace/Resources/Utility/MaterialMappings.xml")) {
+         var materialMappingsPath = PathFinder.GetMaterialMappingsPath();
+         using(StreamWriter writer = new StreamWriter(materialMappingsPath)) {
             var serializer = new XmlSerializer(typeof(Materials));
             serializer.Serialize(writer.BaseStream, AssetManager.data);
             AssetDatabase.Refresh();
@@ -1089,7 +1093,8 @@ Toolbar toolbar;
          if(Index == -1) {
             if(Assets != null && Assets.NeedsToUpdateXML) {
                Assets.AddMaterial(shader);
-               using(StreamWriter writer = new StreamWriter(Application.dataPath + "/TrueTrace/Resources/Utility/MaterialMappings.xml")) {
+               var materialMappingsPath = PathFinder.GetMaterialMappingsPath();
+               using(StreamWriter writer = new StreamWriter(materialMappingsPath)) {
                   var serializer = new XmlSerializer(typeof(Materials));
                   serializer.Serialize(writer.BaseStream, AssetManager.data);
                   AssetDatabase.Refresh();
@@ -2236,7 +2241,8 @@ void AddResolution(int width, int height, string label)
                          }
                       }
                   } catch(System.Exception e) {HasNoMore = true;};
-                  using(StreamWriter writer = new StreamWriter(Application.dataPath + "/TrueTrace/Resources/Utility/SaveFile.xml")) {
+                  var saveFilePath = PathFinder.GetSaveFilePath();
+                  using(StreamWriter writer = new StreamWriter(saveFilePath)) {
                       var serializer = new XmlSerializer(typeof(RayObjs));
                       serializer.Serialize(writer.BaseStream, new RayObjs());
                       UnityEditor.AssetDatabase.Refresh();
@@ -2248,8 +2254,10 @@ void AddResolution(int width, int height, string label)
             if(Assets != null && Instancer != null) RemainingObjectsField.value = Assets.RunningTasks + Instancer.RunningTasks;
             if(RayMaster != null) SampleCountField.value = RayMaster.SampleCount;
             
-            if(Assets != null && Assets.NeedsToUpdateXML) {
-                using(StreamWriter writer = new StreamWriter(Application.dataPath + "/TrueTrace/Resources/Utility/MaterialMappings.xml")) {
+            if(Assets != null && Assets.NeedsToUpdateXML)
+            {
+               var materialMappingsPath = PathFinder.GetMaterialMappingsPath();
+                using(StreamWriter writer = new StreamWriter(materialMappingsPath)) {
                   var serializer = new XmlSerializer(typeof(Materials));
                   serializer.Serialize(writer.BaseStream, AssetManager.data);
                }

--- a/TrueTrace/Editor/PathTracerSettings.cs.meta
+++ b/TrueTrace/Editor/PathTracerSettings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b29ab5a66e61f094981b492c6c57b88f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Editor/RayTracingObjectEditor.cs
+++ b/TrueTrace/Editor/RayTracingObjectEditor.cs
@@ -87,7 +87,8 @@ namespace TrueTrace {
                 if(CopyIndex != -1) PresetRays.RayObj[CopyIndex] = TempRay;
                 else PresetRays.RayObj.Add(TempRay);
 
-                using(StreamWriter writer = new StreamWriter(Application.dataPath + "/TrueTrace/Resources/Utility/MaterialPresets.xml")) {
+                var materialPresetsPath = PathFinder.GetMaterialPresetsPath();
+                using(StreamWriter writer = new StreamWriter(materialPresetsPath)) {
                     var serializer = new XmlSerializer(typeof(RayObjs));
                     serializer.Serialize(writer.BaseStream, PresetRays);
                     UnityEditor.AssetDatabase.Refresh();
@@ -129,7 +130,8 @@ namespace TrueTrace {
                     if(GUILayout.Button(PresetRays.RayObj[i].MatName)) {CallEditorFunction(PresetRays.RayObj[i]); this.editorWindow.Close();}
                     if(GUILayout.Button("Delete")) {
                         PresetRays.RayObj.RemoveAt(i);
-                        using(StreamWriter writer = new StreamWriter(Application.dataPath + "/TrueTrace/Resources/Utility/MaterialPresets.xml")) {
+                        var materialPresetPath = PathFinder.GetMaterialPresetsPath();
+                        using(StreamWriter writer = new StreamWriter(materialPresetPath)) {
                             var serializer = new XmlSerializer(typeof(RayObjs));
                             serializer.Serialize(writer.BaseStream, PresetRays);
                             UnityEditor.AssetDatabase.Refresh();

--- a/TrueTrace/Editor/RayTracingObjectEditor.cs.meta
+++ b/TrueTrace/Editor/RayTracingObjectEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 609244068e62bbb4fab5c00e3c4e987d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Editor/RenderingPipelineDefines.cs
+++ b/TrueTrace/Editor/RenderingPipelineDefines.cs
@@ -1,6 +1,7 @@
 #if UNITY_EDITOR
 using System.Collections.Generic;
 using System.Linq;
+using TrueTrace;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.Rendering;
@@ -21,9 +22,11 @@ public class RenderingPipelineDefines
         UpdateDefines();
     }
 
-    static void SetGlobalDefines(string DefineToSet, bool SetValue) {
-        if(System.IO.File.Exists(Application.dataPath + "/TrueTrace/Resources/GlobalDefines.cginc")) {
-            string[] GlobalDefines = System.IO.File.ReadAllLines(Application.dataPath + "/TrueTrace/Resources/GlobalDefines.cginc");
+    static void SetGlobalDefines(string DefineToSet, bool SetValue)
+    {
+        var globalDefinesPath = PathFinder.GetGlobalDefinesPath();
+        if(System.IO.File.Exists(globalDefinesPath)) {
+            string[] GlobalDefines = System.IO.File.ReadAllLines(globalDefinesPath);
             int Index = -1;
             for(int i = 0; i < GlobalDefines.Length; i++) {
                 if(GlobalDefines[i].Equals("//END OF DEFINES")) break;
@@ -41,7 +44,7 @@ public class RenderingPipelineDefines
             GlobalDefines[Index] = GlobalDefines[Index].Replace("// ", "");
             if(!SetValue) GlobalDefines[Index] = "// " + GlobalDefines[Index];
 
-            System.IO.File.WriteAllLines(Application.dataPath + "/TrueTrace/Resources/GlobalDefines.cginc", GlobalDefines);
+            System.IO.File.WriteAllLines(globalDefinesPath, GlobalDefines);
             AssetDatabase.Refresh();
         } else {Debug.Log("No GlobalDefinesFile");}
     }

--- a/TrueTrace/Editor/RenderingPipelineDefines.cs.meta
+++ b/TrueTrace/Editor/RenderingPipelineDefines.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fcb2cef0318a89148a01ec76405bb371
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Editor/TrueTraceEditor.asmdef
+++ b/TrueTrace/Editor/TrueTraceEditor.asmdef
@@ -3,7 +3,8 @@
     "rootNamespace": "",
     "references": [
         "GUID:ed514bd980ff3ea46904db26e115c21d",
-        "GUID:457756d89b35d2941b3e7b37b4ece6f1"
+        "GUID:457756d89b35d2941b3e7b37b4ece6f1",
+        "GUID:a0c582bf036553c45ad7839077e3a14f"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/TrueTrace/Editor/TrueTraceEditor.asmdef.meta
+++ b/TrueTrace/Editor/TrueTraceEditor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 33a22091d64a17b4590ba78210176aa1
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Editor/WaveV2Editor.cs.meta
+++ b/TrueTrace/Editor/WaveV2Editor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 82732c693ab02b34bab108f7157605dc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/GettingStarted.txt.meta
+++ b/TrueTrace/GettingStarted.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8d14873eebe8a2d4588e8743817f37a9
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/LICENSE.txt.meta
+++ b/TrueTrace/LICENSE.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0b53ff7bb73e2f047a377bb832351a85
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models.meta
+++ b/TrueTrace/Models.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2beff443316a1984d8975f17da440a09
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2).meta
+++ b/TrueTrace/Models/1sponza (2).meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5ffac1ca18640664f876430e6ab80715
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9ec4c7c5be9b11147a91ce36580d1dea
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/Material__25.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/Material__25.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ecfb631bc1819804dbf20bef1ccf19a8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/Material__298.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/Material__298.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6a3cfa0c8ec0d254c8b32d6f301754f0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/Material__47.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/Material__47.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 21683ea384bf0d346b3cc3f549442331
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/Material__57.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/Material__57.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 04623c6a34e26e14280b4a1a6d96761a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/arch.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/arch.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 916ba9eab135ad243afa976e4989860b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/background.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/background.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 70d1b2c5ba5687f4b94333056e3f16f4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/bricks.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/bricks.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5a621ab766a42c140ad56a92517ca773
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/ceiling.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/ceiling.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 94a98d7f4d093d949bcdaab28ed316e9
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/chain.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/chain.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b2e6531616efc644894a59aa232e5049
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/chain_texture.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/chain_texture.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 36d3b2f4d7fe6d34bbe9a624e4f4e5e8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/column_a.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/column_a.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e6af682146d839d4c8749f4a2b8c86f2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/column_b.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/column_b.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4af8179c55c83834d95baed05bbd37fc
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/column_c.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/column_c.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4f9f5e71a51f0fe43963f07146688617
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/details.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/details.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7d223861015d72f47a5575d1d12fba87
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/fabric_a.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/fabric_a.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ff12e45bcbf267d488314cc3a245a532
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/fabric_c.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/fabric_c.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 80a01c28eb1b6a64d9901099c0ceabc5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/fabric_d.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/fabric_d.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3a4c8795dc2bc384d9f0b164d38207fd
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/fabric_e.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/fabric_e.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d4b4b5f2cbda7ad4ca8433836e506044
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/fabric_f.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/fabric_f.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7a27c8fe0b856b148bba5eb2cfc201f4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/fabric_g.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/fabric_g.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d6828ec3f7ec4e343834a8d672419024
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/flagpole.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/flagpole.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 286d685f03ce1f04daf8efbd4ddc24dd
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/floor.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/floor.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2623b6056c76ea24f8d0dc1d39d9baba
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/leaf.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/leaf.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c908d019a2939ce44982d19b10ad2b68
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/lion.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/lion.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c8751376b03ade24097cf48e753d4f6b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/roof.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/roof.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ad374d1a7e1676a458516cb3a102a463
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/spnza_bricks_a_diff.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/spnza_bricks_a_diff.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d3ab3e4a5637c6545a279bc1550df561
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/sponza_arch_diff.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/sponza_arch_diff.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5a8b5fa6021d0324680d4175de331721
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/sponza_ceiling_a_diff.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/sponza_ceiling_a_diff.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c4009d7ef14ebcf4bac942abff6e80a5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/sponza_column_a_diff.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/sponza_column_a_diff.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 05ff0b348a2c6864e8d2797ad3b7d57b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/sponza_column_b_diff.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/sponza_column_b_diff.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8f325f31ea8f9694fbcfc6fff443a7c2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/sponza_column_c_diff.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/sponza_column_c_diff.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a31083d47ccb80e42804702c0f8d9ac8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/sponza_curtain_blue_diff.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/sponza_curtain_blue_diff.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f96b36eeb2d00564783f5e2c9936f95f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/sponza_curtain_diff.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/sponza_curtain_diff.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d875d12b9f15ba243ac14b905960b2f4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/sponza_curtain_green_diff.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/sponza_curtain_green_diff.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 11a6a1ede60d77b409fc623a1c1d90bd
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/sponza_details_diff.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/sponza_details_diff.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: aa224a859493ab0419778c45b462102d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/sponza_fabric_blue_diff.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/sponza_fabric_blue_diff.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3039c58cbc7627f4083b851c9dbaf2f0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/sponza_fabric_diff.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/sponza_fabric_diff.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d2b5a7803d946f545865ce8911ca3aa8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/sponza_fabric_green_diff.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/sponza_fabric_green_diff.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 518a5ef1f07b6034d93f0931d0d84313
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/sponza_flagpole_diff.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/sponza_flagpole_diff.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 651959b2d28cecc4085bd67f767a0c93
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/sponza_floor_a_diff.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/sponza_floor_a_diff.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dbc87b2fca1fa144d81431cd345b262e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/sponza_roof_diff.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/sponza_roof_diff.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cbd04db6764b0b04db25711d82dc17e2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/sponza_thorn_diff.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/sponza_thorn_diff.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 40278d1c9591dcb42a12d9d8e16ae16b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/vase.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/vase.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 70191ee40f9ad334cb1862578ce84fc0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/vase_dif.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/vase_dif.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 71ca99fa87c1e5f4b8a061cc9d21b921
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/vase_hanging.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/vase_hanging.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 173c544e52b06a14dbc4e0f439796b97
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/vase_plant.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/vase_plant.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: afb1787321cb54046852113c00594b95
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/Materials/vase_round.mat.meta
+++ b/TrueTrace/Models/1sponza (2)/Materials/vase_round.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e484bb6dee6937c4a80cae0c51cbd5db
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/sponza.mtl.meta
+++ b/TrueTrace/Models/1sponza (2)/sponza.mtl.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 537a29f64ef44664d9f866ec87257ef9
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/sponza.obj.meta
+++ b/TrueTrace/Models/1sponza (2)/sponza.obj.meta
@@ -1,0 +1,109 @@
+fileFormatVersion: 2
+guid: 6ff131210fe47dc4b9af0f2f89045025
+ModelImporter:
+  serializedVersion: 22200
+  internalIDToNameTable: []
+  externalObjects: {}
+  materials:
+    materialImportMode: 2
+    materialName: 0
+    materialSearch: 1
+    materialLocation: 1
+  animations:
+    legacyGenerateAnimations: 4
+    bakeSimulation: 0
+    resampleCurves: 1
+    optimizeGameObjects: 0
+    removeConstantScaleCurves: 0
+    motionNodeName: 
+    rigImportErrors: 
+    rigImportWarnings: 
+    animationImportErrors: 
+    animationImportWarnings: 
+    animationRetargetingWarnings: 
+    animationDoRetargetingWarnings: 0
+    importAnimatedCustomProperties: 0
+    importConstraints: 0
+    animationCompression: 1
+    animationRotationError: 0.5
+    animationPositionError: 0.5
+    animationScaleError: 0.5
+    animationWrapMode: 0
+    extraExposedTransformPaths: []
+    extraUserProperties: []
+    clipAnimations: []
+    isReadable: 0
+  meshes:
+    lODScreenPercentages: []
+    globalScale: 1
+    meshCompression: 0
+    addColliders: 0
+    useSRGBMaterialColor: 1
+    sortHierarchyByName: 1
+    importPhysicalCameras: 1
+    importVisibility: 1
+    importBlendShapes: 1
+    importCameras: 1
+    importLights: 1
+    nodeNameCollisionStrategy: 1
+    fileIdsGeneration: 2
+    swapUVChannels: 0
+    generateSecondaryUV: 0
+    useFileUnits: 1
+    keepQuads: 0
+    weldVertices: 1
+    bakeAxisConversion: 0
+    preserveHierarchy: 0
+    skinWeightsMode: 0
+    maxBonesPerVertex: 4
+    minBoneWeight: 0.001
+    optimizeBones: 1
+    meshOptimizationFlags: -1
+    indexFormat: 0
+    secondaryUVAngleDistortion: 8
+    secondaryUVAreaDistortion: 15.000001
+    secondaryUVHardAngle: 88
+    secondaryUVMarginMethod: 1
+    secondaryUVMinLightmapResolution: 40
+    secondaryUVMinObjectScale: 1
+    secondaryUVPackMargin: 4
+    useFileScale: 1
+    strictVertexDataChecks: 0
+  tangentSpace:
+    normalSmoothAngle: 60
+    normalImportMode: 0
+    tangentImportMode: 3
+    normalCalculationMode: 4
+    legacyComputeAllNormalsFromSmoothingGroupsWhenMeshHasBlendShapes: 0
+    blendShapeNormalImportMode: 1
+    normalSmoothingSource: 0
+  referencedClips: []
+  importAnimation: 1
+  humanDescription:
+    serializedVersion: 3
+    human: []
+    skeleton: []
+    armTwist: 0.5
+    foreArmTwist: 0.5
+    upperLegTwist: 0.5
+    legTwist: 0.5
+    armStretch: 0.05
+    legStretch: 0.05
+    feetSpacing: 0
+    globalScale: 1
+    rootMotionBoneName: 
+    hasTranslationDoF: 0
+    hasExtraRoot: 0
+    skeletonHasParents: 1
+  lastHumanDescriptionAvatarSource: {instanceID: 0}
+  autoGenerateAvatarMappingIfUnspecified: 1
+  animationType: 2
+  humanoidOversampling: 1
+  avatarSetup: 0
+  addHumanoidExtraRootOnlyWhenUsingAvatar: 1
+  importBlendShapeDeformPercent: 1
+  remapMaterialsIfMaterialImportModeIsNone: 0
+  additionalBone: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/textures.meta
+++ b/TrueTrace/Models/1sponza (2)/textures.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2f0d405250897454d9eafb5da0ea045d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/textures/background.png.meta
+++ b/TrueTrace/Models/1sponza (2)/textures/background.png.meta
@@ -1,0 +1,114 @@
+fileFormatVersion: 2
+guid: 3ecc32930b0e11548a1abe9edf4be63e
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/textures/chain_texture.png.meta
+++ b/TrueTrace/Models/1sponza (2)/textures/chain_texture.png.meta
@@ -1,0 +1,114 @@
+fileFormatVersion: 2
+guid: 3fd7e2defb7b42a4484a35d2f162c499
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/textures/lion.png.meta
+++ b/TrueTrace/Models/1sponza (2)/textures/lion.png.meta
@@ -1,0 +1,114 @@
+fileFormatVersion: 2
+guid: 652934fde8a31554d9df64e351befcb5
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/textures/spnza_bricks_a_diff.png.meta
+++ b/TrueTrace/Models/1sponza (2)/textures/spnza_bricks_a_diff.png.meta
@@ -1,0 +1,114 @@
+fileFormatVersion: 2
+guid: 424bb1c546ffaae4e900db75d9a43e06
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/textures/sponza_arch_diff.png.meta
+++ b/TrueTrace/Models/1sponza (2)/textures/sponza_arch_diff.png.meta
@@ -1,0 +1,114 @@
+fileFormatVersion: 2
+guid: 7e7e0f93c5d7f344f9cebddd34600bc3
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/textures/sponza_ceiling_a_diff.png.meta
+++ b/TrueTrace/Models/1sponza (2)/textures/sponza_ceiling_a_diff.png.meta
@@ -1,0 +1,114 @@
+fileFormatVersion: 2
+guid: 3448caad74c9f144a9fc2ea7a183d99a
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/textures/sponza_column_a_diff.png.meta
+++ b/TrueTrace/Models/1sponza (2)/textures/sponza_column_a_diff.png.meta
@@ -1,0 +1,114 @@
+fileFormatVersion: 2
+guid: 608fffe34ef82944a8ab9754a05bd560
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/textures/sponza_column_b_diff.png.meta
+++ b/TrueTrace/Models/1sponza (2)/textures/sponza_column_b_diff.png.meta
@@ -1,0 +1,114 @@
+fileFormatVersion: 2
+guid: fb84180338b131d40a192a96a2eeb240
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/textures/sponza_column_c_diff.png.meta
+++ b/TrueTrace/Models/1sponza (2)/textures/sponza_column_c_diff.png.meta
@@ -1,0 +1,114 @@
+fileFormatVersion: 2
+guid: a9eedcba11e79234b8fda1613e8820e6
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/textures/sponza_curtain_blue_diff.png.meta
+++ b/TrueTrace/Models/1sponza (2)/textures/sponza_curtain_blue_diff.png.meta
@@ -1,0 +1,114 @@
+fileFormatVersion: 2
+guid: 647f54ed9dbb7a448a63ea87e8ed0127
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/textures/sponza_curtain_diff.png.meta
+++ b/TrueTrace/Models/1sponza (2)/textures/sponza_curtain_diff.png.meta
@@ -1,0 +1,114 @@
+fileFormatVersion: 2
+guid: b6764526393d62847a9dd19b49b6627d
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/textures/sponza_curtain_green_diff.png.meta
+++ b/TrueTrace/Models/1sponza (2)/textures/sponza_curtain_green_diff.png.meta
@@ -1,0 +1,114 @@
+fileFormatVersion: 2
+guid: 3353373dbc2e25d41873e47d0cc4fadb
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/textures/sponza_details_diff.png.meta
+++ b/TrueTrace/Models/1sponza (2)/textures/sponza_details_diff.png.meta
@@ -1,0 +1,114 @@
+fileFormatVersion: 2
+guid: d86c184d72153804cb220b3976f12815
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/textures/sponza_fabric_blue_diff.png.meta
+++ b/TrueTrace/Models/1sponza (2)/textures/sponza_fabric_blue_diff.png.meta
@@ -1,0 +1,114 @@
+fileFormatVersion: 2
+guid: abe0880c44b4fd24ba1886c8f726cc43
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/textures/sponza_fabric_diff.png.meta
+++ b/TrueTrace/Models/1sponza (2)/textures/sponza_fabric_diff.png.meta
@@ -1,0 +1,114 @@
+fileFormatVersion: 2
+guid: ed7a459ac2b482c4cb34c948f52757e7
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/textures/sponza_fabric_green_diff.png.meta
+++ b/TrueTrace/Models/1sponza (2)/textures/sponza_fabric_green_diff.png.meta
@@ -1,0 +1,114 @@
+fileFormatVersion: 2
+guid: 38d6c84b4014b4c4eb7b0218c0d334b7
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/textures/sponza_flagpole_diff.png.meta
+++ b/TrueTrace/Models/1sponza (2)/textures/sponza_flagpole_diff.png.meta
@@ -1,0 +1,114 @@
+fileFormatVersion: 2
+guid: ab0f9564496d79945a7c9d87fd33c2d9
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/textures/sponza_floor_a_diff.png.meta
+++ b/TrueTrace/Models/1sponza (2)/textures/sponza_floor_a_diff.png.meta
@@ -1,0 +1,114 @@
+fileFormatVersion: 2
+guid: 75e5143c8ec44de4ba8438e3f25d733f
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/textures/sponza_roof_diff.png.meta
+++ b/TrueTrace/Models/1sponza (2)/textures/sponza_roof_diff.png.meta
@@ -1,0 +1,114 @@
+fileFormatVersion: 2
+guid: 88822fa2b3d13d24286e29628c4ed242
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/textures/sponza_thorn_diff.png.meta
+++ b/TrueTrace/Models/1sponza (2)/textures/sponza_thorn_diff.png.meta
@@ -1,0 +1,114 @@
+fileFormatVersion: 2
+guid: 4c86b2d1a97beb14a8343c4827b7b435
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/textures/vase_dif.png.meta
+++ b/TrueTrace/Models/1sponza (2)/textures/vase_dif.png.meta
@@ -1,0 +1,114 @@
+fileFormatVersion: 2
+guid: 14d43475f28d01042a789a80cd796292
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/textures/vase_hanging.png.meta
+++ b/TrueTrace/Models/1sponza (2)/textures/vase_hanging.png.meta
@@ -1,0 +1,114 @@
+fileFormatVersion: 2
+guid: 1ee4ba09adff5b848b70049dc75c1c48
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/textures/vase_plant.png.meta
+++ b/TrueTrace/Models/1sponza (2)/textures/vase_plant.png.meta
@@ -1,0 +1,114 @@
+fileFormatVersion: 2
+guid: 99f8e768b5d926a4e9d2c105895ab633
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Models/1sponza (2)/textures/vase_round.png.meta
+++ b/TrueTrace/Models/1sponza (2)/textures/vase_round.png.meta
@@ -1,0 +1,114 @@
+fileFormatVersion: 2
+guid: a66785ec7c029a94c9a90fef477ce607
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources.meta
+++ b/TrueTrace/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 31af67c62414ffb459682517a9b69038
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/AssetManager.cs.meta
+++ b/TrueTrace/Resources/AssetManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c5190299396ed4e429868898b5a1b09c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/BindlessArray.cs.meta
+++ b/TrueTrace/Resources/BindlessArray.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e34a7aa986e99e3418e0672c4c78debb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Builders.meta
+++ b/TrueTrace/Resources/Builders.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bbfa3d4b6444cac4392e6fb76c2d7974
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Builders/BVH2Builder.cs.meta
+++ b/TrueTrace/Resources/Builders/BVH2Builder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 374c4f3ae4225ff439ca75db4b59a822
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Builders/BVH8Builder.cs.meta
+++ b/TrueTrace/Resources/Builders/BVH8Builder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 385395c4f0b4e9648be3692558639df5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Builders/CommonVars.cs.meta
+++ b/TrueTrace/Resources/Builders/CommonVars.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f21fd518ffa92ff45a187f3fe55930fc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Builders/InstancedManager.cs.meta
+++ b/TrueTrace/Resources/Builders/InstancedManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5b4886734a6a64948adcb6758a2024de
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Builders/LightBVHBuilder.cs.meta
+++ b/TrueTrace/Resources/Builders/LightBVHBuilder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b7b4122670d0c2c45a6470d378252465
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/GlobalDefines.cginc.meta
+++ b/TrueTrace/Resources/GlobalDefines.cginc.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f163684574038d24a9e8e65c98628593
+ShaderIncludeImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/MainCompute.meta
+++ b/TrueTrace/Resources/MainCompute.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0dcb1c092db7c994787e6dc7a213a45b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/MainCompute/CommonData.cginc.meta
+++ b/TrueTrace/Resources/MainCompute/CommonData.cginc.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4cd40aa7a3c31424e82a36251fde8024
+ShaderIncludeImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/MainCompute/CommonStructs.cginc.meta
+++ b/TrueTrace/Resources/MainCompute/CommonStructs.cginc.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 93d0e40784995df47aa66f052db7f539
+ShaderIncludeImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/MainCompute/IntersectionKernels.compute.meta
+++ b/TrueTrace/Resources/MainCompute/IntersectionKernels.compute.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9a71202a18c3f5f48850f6b5a1e408cd
+ComputeShaderImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/MainCompute/Materials.cginc.meta
+++ b/TrueTrace/Resources/MainCompute/Materials.cginc.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 28bbf8723fc2cad42ae83c02d6e4d492
+ShaderIncludeImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/MainCompute/RayGenKernels.compute.meta
+++ b/TrueTrace/Resources/MainCompute/RayGenKernels.compute.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ec9f927687ab3924f9f3c464492f86a1
+ComputeShaderImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/MainCompute/RayTracingShader.compute.meta
+++ b/TrueTrace/Resources/MainCompute/RayTracingShader.compute.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e85a5bc91d3644742b5c90faba72a1c1
+ComputeShaderImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/MainCompute/ReSTIRGI.compute.meta
+++ b/TrueTrace/Resources/MainCompute/ReSTIRGI.compute.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 38f5c570d854bc640b52327f01ac3f29
+ComputeShaderImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Objects.meta
+++ b/TrueTrace/Resources/Objects.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7464f838c17108f4186fe114d2f38fd3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Objects/InstancedObject.cs.meta
+++ b/TrueTrace/Resources/Objects/InstancedObject.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c0a4201ae6607954b8aad6cc459739c9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Objects/ParentObject.cs.meta
+++ b/TrueTrace/Resources/Objects/ParentObject.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8cc57734292556c4984a4e3ace125d33
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Objects/RayTracingLights.cs.meta
+++ b/TrueTrace/Resources/Objects/RayTracingLights.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bb0d9d7ea229eaf47872f918110f6038
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Objects/RayTracingObject.cs.meta
+++ b/TrueTrace/Resources/Objects/RayTracingObject.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4ba1d0bc349bb6041ab85c8a945b812e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Objects/TerrainObject.cs.meta
+++ b/TrueTrace/Resources/Objects/TerrainObject.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5ecd9d480a677b64e942f1abb23da073
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/PostProcess.meta
+++ b/TrueTrace/Resources/PostProcess.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 48a4640b08f10e440927baee1e3efcad
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/PostProcess/ASVGF.meta
+++ b/TrueTrace/Resources/PostProcess/ASVGF.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e081ad828fae8b941ae3c08fae613697
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/PostProcess/ASVGF/ASVGF.compute.meta
+++ b/TrueTrace/Resources/PostProcess/ASVGF/ASVGF.compute.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d4537e1c3a369a84bb50bab2ba3943ad
+ComputeShaderImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/PostProcess/ASVGF/ASVGF.cs.meta
+++ b/TrueTrace/Resources/PostProcess/ASVGF/ASVGF.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3558a0ca828ef0544a7869269570d500
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/PostProcess/Compute.meta
+++ b/TrueTrace/Resources/PostProcess/Compute.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9e234dfb9b5fff0479f147abde2127cc
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/PostProcess/Compute/AutoExpose.compute.meta
+++ b/TrueTrace/Resources/PostProcess/Compute/AutoExpose.compute.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 99d344673ea351a4d9cc04a73d39458b
+ComputeShaderImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/PostProcess/Compute/Bloom.compute.meta
+++ b/TrueTrace/Resources/PostProcess/Compute/Bloom.compute.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7ef96c0577e85514e955abb95fa6e0c8
+ComputeShaderImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/PostProcess/Compute/SVGF.compute.meta
+++ b/TrueTrace/Resources/PostProcess/Compute/SVGF.compute.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 48561353ccf2937468e79086462ba215
+ComputeShaderImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/PostProcess/Compute/Sharpen.compute.meta
+++ b/TrueTrace/Resources/PostProcess/Compute/Sharpen.compute.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1460f457f19f183448e4aebb3c98979d
+ComputeShaderImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/PostProcess/Compute/TAA.compute.meta
+++ b/TrueTrace/Resources/PostProcess/Compute/TAA.compute.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 50b484438db53d2478ed36df63009b17
+ComputeShaderImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/PostProcess/Compute/TAAU.compute.meta
+++ b/TrueTrace/Resources/PostProcess/Compute/TAAU.compute.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 36fd6da6218c055418b92697499f5784
+ComputeShaderImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/PostProcess/Compute/ToneMap.compute.meta
+++ b/TrueTrace/Resources/PostProcess/Compute/ToneMap.compute.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: de764ac89dd68d94bb063bd24c84b178
+ComputeShaderImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/PostProcess/Compute/Upscaler.compute.meta
+++ b/TrueTrace/Resources/PostProcess/Compute/Upscaler.compute.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 821cad68878b13c4f9e4670f7657af67
+ComputeShaderImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/PostProcess/Denoiser.cs.meta
+++ b/TrueTrace/Resources/PostProcess/Denoiser.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 02d4d9b8150bca84f85c3569f3112a3c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/PostProcess/DenoisersCommon.cginc.meta
+++ b/TrueTrace/Resources/PostProcess/DenoisersCommon.cginc.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 60fe3c5c5eda0cc4ea9f8011772d77c1
+ShaderIncludeImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/PostProcess/ReSTIRASVGF.meta
+++ b/TrueTrace/Resources/PostProcess/ReSTIRASVGF.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 249eedf12f004cc4882cd5bb7d75230d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/PostProcess/ReSTIRASVGF/ReSTIRASVGF.compute.meta
+++ b/TrueTrace/Resources/PostProcess/ReSTIRASVGF/ReSTIRASVGF.compute.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7e0915e134bfdbd40a7df3e14657451e
+ComputeShaderImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/PostProcess/ReSTIRASVGF/ReSTIRASVGF.cs.meta
+++ b/TrueTrace/Resources/PostProcess/ReSTIRASVGF/ReSTIRASVGF.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 93f6dd9324927884295d7be98ddafef7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/RayTracingMaster.cs
+++ b/TrueTrace/Resources/RayTracingMaster.cs
@@ -302,20 +302,26 @@ namespace TrueTrace {
             }
         }
 
-        private void OnEnable() {
+        private void OnEnable()
+        {
             _currentSample = 0;
         }
 
-        void OnDestroy() {
-            #if UNITY_EDITOR
-                using(StreamWriter writer = new StreamWriter(Application.dataPath + "/TrueTrace/Resources/Utility/SaveFile.xml")) {
-                    var serializer = new XmlSerializer(typeof(RayObjs));
-                    serializer.Serialize(writer.BaseStream, raywrites);
-                    UnityEditor.AssetDatabase.Refresh();
-                }
-            #endif
+        void OnDestroy()
+        {
+#if UNITY_EDITOR
+
+            var saveFilePath = PathFinder.GetSaveFilePath();
+            using (StreamWriter writer = new StreamWriter(saveFilePath))
+            {
+                var serializer = new XmlSerializer(typeof(RayObjs));
+                serializer.Serialize(writer.BaseStream, raywrites);
+                UnityEditor.AssetDatabase.Refresh();
+            }
+#endif
         }
-        public void OnDisable() {
+
+    public void OnDisable() {
             DoCheck = true;
             _RayBuffer?.Release();
             LightingBuffer?.Release();

--- a/TrueTrace/Resources/RayTracingMaster.cs.meta
+++ b/TrueTrace/Resources/RayTracingMaster.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: af7ffc420c3d64947abba94d1be8c966
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/RenderPipelines.meta
+++ b/TrueTrace/Resources/RenderPipelines.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e0134c018f7fcd140af634b51ceaa44e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/RenderPipelines/HDRPCompatability.cs.meta
+++ b/TrueTrace/Resources/RenderPipelines/HDRPCompatability.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 986adc70cdb20784482635ca2e88b409
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/RenderPipelines/RenderHandle.cs.meta
+++ b/TrueTrace/Resources/RenderPipelines/RenderHandle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2a5f8ad7d5f17374794e7dd44343b641
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/RenderPipelines/URPCompatability.cs.meta
+++ b/TrueTrace/Resources/RenderPipelines/URPCompatability.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 999685fcf8cd2ac4dabb9ba835ec2855
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Utility.meta
+++ b/TrueTrace/Resources/Utility.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e2dbf62f61b71184a91ffcb60df7b3bd
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Utility/Accumulate.shader.meta
+++ b/TrueTrace/Resources/Utility/Accumulate.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 7bb8bf7ad54ea6947949671dd027579b
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Utility/AgXBC.exr.meta
+++ b/TrueTrace/Resources/Utility/AgXBC.exr.meta
@@ -1,0 +1,114 @@
+fileFormatVersion: 2
+guid: 4b45556acd7132940b0d1e0c82efd085
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Utility/Atmosphere.meta
+++ b/TrueTrace/Resources/Utility/Atmosphere.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a99feb8829459a14d9dc694b07cdcb7d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Utility/Atmosphere/AtmosphereGenerator.cs.meta
+++ b/TrueTrace/Resources/Utility/Atmosphere/AtmosphereGenerator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5ef97495cc0f5d843ba83e5ffcf14739
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Utility/Atmosphere/AtmosphereLUTGenerator.compute.meta
+++ b/TrueTrace/Resources/Utility/Atmosphere/AtmosphereLUTGenerator.compute.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a7f4aea0849884e42b3f602b82270716
+ComputeShaderImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Utility/Atmosphere/AtmosphereSampling.cginc.meta
+++ b/TrueTrace/Resources/Utility/Atmosphere/AtmosphereSampling.cginc.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 70e49c54f464b744395c355300a587cb
+ShaderIncludeImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Utility/BVHRefitter.compute.meta
+++ b/TrueTrace/Resources/Utility/BVHRefitter.compute.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 560362c4fc393844fa0173ad18a37a26
+ComputeShaderImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Utility/CDFCreator.compute.meta
+++ b/TrueTrace/Resources/Utility/CDFCreator.compute.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 02050f5bc62e5254c958a299bdfc96c8
+ComputeShaderImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Utility/CopyTextureShader.compute.meta
+++ b/TrueTrace/Resources/Utility/CopyTextureShader.compute.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: dce1559911cd74042a418afefc65c2ea
+ComputeShaderImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Utility/DING.mp3.meta
+++ b/TrueTrace/Resources/Utility/DING.mp3.meta
@@ -1,0 +1,23 @@
+fileFormatVersion: 2
+guid: 23de802214e251e4aae0c502d1412aee
+AudioImporter:
+  externalObjects: {}
+  serializedVersion: 7
+  defaultSettings:
+    serializedVersion: 2
+    loadType: 0
+    sampleRateSetting: 0
+    sampleRateOverride: 44100
+    compressionFormat: 1
+    quality: 1
+    conversionMode: 0
+    preloadAudioData: 0
+  platformSettingOverrides: {}
+  forceToMono: 0
+  normalize: 1
+  loadInBackground: 0
+  ambisonic: 0
+  3D: 1
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Utility/External.meta
+++ b/TrueTrace/Resources/Utility/External.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 51d8e858220f92140b54c346cba418e1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Utility/External/AMD_Compressonator.meta
+++ b/TrueTrace/Resources/Utility/External/AMD_Compressonator.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0ea0e2f86b0ddcd458be215f55560938
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Utility/External/AMD_Compressonator/bcn_common_api.h.meta
+++ b/TrueTrace/Resources/Utility/External/AMD_Compressonator/bcn_common_api.h.meta
@@ -1,0 +1,27 @@
+fileFormatVersion: 2
+guid: 301c211cd02bd2944a9cc3b55ede5b2a
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Utility/External/AMD_Compressonator/bcn_common_kernel.h.meta
+++ b/TrueTrace/Resources/Utility/External/AMD_Compressonator/bcn_common_kernel.h.meta
@@ -1,0 +1,27 @@
+fileFormatVersion: 2
+guid: fa0e7ae923fc62741b098f6e37433c64
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Utility/External/AMD_Compressonator/common_def.h.meta
+++ b/TrueTrace/Resources/Utility/External/AMD_Compressonator/common_def.h.meta
@@ -1,0 +1,27 @@
+fileFormatVersion: 2
+guid: 9d9a2d3fc838bfc42a4ccf5007554544
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Utility/FireFlyPass.shader.meta
+++ b/TrueTrace/Resources/Utility/FireFlyPass.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 2478c566b1808db44a5a82d2aa88f619
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Utility/FlyCamera.cs.meta
+++ b/TrueTrace/Resources/Utility/FlyCamera.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a953dee8b0256de4fb98ee12da071c74
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Utility/GeneralMeshFunctions.compute.meta
+++ b/TrueTrace/Resources/Utility/GeneralMeshFunctions.compute.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5d26c71f90b6b03469c24f98a92a92ec
+ComputeShaderImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Utility/LightBVHRefitter.compute.meta
+++ b/TrueTrace/Resources/Utility/LightBVHRefitter.compute.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 81baadce30797be4d85212077703982e
+ComputeShaderImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Utility/MaterialMappings.xml.meta
+++ b/TrueTrace/Resources/Utility/MaterialMappings.xml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 904fdf82e5b01d24ca20a44cbf70d0c6
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Utility/MaterialPresets.xml.meta
+++ b/TrueTrace/Resources/Utility/MaterialPresets.xml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6eaedaf09f4ef6a4ebe615268bb3107f
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Utility/PanoramaDoer.cs.meta
+++ b/TrueTrace/Resources/Utility/PanoramaDoer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6dfebfc80a268fd42b0bb1f4045fc373
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Utility/Pathfinder.cs
+++ b/TrueTrace/Resources/Utility/Pathfinder.cs
@@ -1,0 +1,47 @@
+using System;
+using System.IO;
+using UnityEngine;
+
+namespace TrueTrace
+{
+    public static class PathFinder
+    {
+        private static string baseResourcePath;
+
+        public static string GetResourcePath()
+        {
+            if (!string.IsNullOrEmpty(baseResourcePath))
+                return NormalizePath(baseResourcePath);
+
+            // Use more precise search parameters to reduce overhead and potential errors
+            var searchPattern = "Resources";
+            var directories = Directory.GetDirectories(Application.dataPath, searchPattern, SearchOption.AllDirectories);
+
+            foreach (var dir in directories)
+            {
+                string normalizedDir = NormalizePath(dir);
+                
+                if (normalizedDir.EndsWith("/TrueTrace/Resources"))
+                {
+                    baseResourcePath = normalizedDir;
+                    return normalizedDir;
+                }
+            }
+
+            Debug.LogError("Resource path not found.");  // Use Error logging for better visibility
+            throw new Exception("Resource path not found.");
+        }
+        
+        private static string NormalizePath(string path)
+        {
+            // Always use forward slashes to prevent platform-specific issues
+            return Path.Combine(path).Replace('\\', '/');
+        }
+
+        // Ensure all paths returned from these methods are normalized
+        public static string GetSaveFilePath() => NormalizePath(Path.Combine(GetResourcePath(), "Utility/SaveFile.xml"));
+        public static string GetGlobalDefinesPath() => NormalizePath(Path.Combine(GetResourcePath(), "GlobalDefines.cginc"));
+        public static string GetMaterialPresetsPath() => NormalizePath(Path.Combine(GetResourcePath(), "Utility/MaterialPresets.xml"));
+        public static string GetMaterialMappingsPath() => NormalizePath(Path.Combine(GetResourcePath(), "Utility/MaterialMappings.xml"));
+    }
+}

--- a/TrueTrace/Resources/Utility/Pathfinder.cs.meta
+++ b/TrueTrace/Resources/Utility/Pathfinder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 06cecd109333bc94d9366d45cca17ca0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Utility/RectpackSharp.meta
+++ b/TrueTrace/Resources/Utility/RectpackSharp.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 07b854a357ffff842b1d036042510d87
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Utility/RectpackSharp/RectanglePacker.cs.meta
+++ b/TrueTrace/Resources/Utility/RectpackSharp/RectanglePacker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f3728bdeafe1e2c4f9a171dd235dbe01
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Utility/SaveFile.xml.meta
+++ b/TrueTrace/Resources/Utility/SaveFile.xml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4d1f9961fd2c4f242bd8b3bbdfa36e09
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Utility/TTSettings.cs.meta
+++ b/TrueTrace/Resources/Utility/TTSettings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 38e01900389436248951dd7bc68e4736
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Utility/ToneMapTex.asset.meta
+++ b/TrueTrace/Resources/Utility/ToneMapTex.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 99e0e0d6971653548ace71f970afcf5c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Utility/UnifiedSimpleAnimation.cs.meta
+++ b/TrueTrace/Resources/Utility/UnifiedSimpleAnimation.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 93db250fa7f3df746b45592193a47a03
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Utility/UnityDenoiserPlugin.meta
+++ b/TrueTrace/Resources/Utility/UnityDenoiserPlugin.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3f7db0cd6b4aef24a9582a9d884c4c69
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Utility/UnityDenoiserPlugin/OpenImageDenoise2.dll.meta
+++ b/TrueTrace/Resources/Utility/UnityDenoiserPlugin/OpenImageDenoise2.dll.meta
@@ -1,0 +1,27 @@
+fileFormatVersion: 2
+guid: d8b42da81da300a4fad971c9a8494309
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Utility/UnityDenoiserPlugin/OpenImageDenoise_core.dll.meta
+++ b/TrueTrace/Resources/Utility/UnityDenoiserPlugin/OpenImageDenoise_core.dll.meta
@@ -1,0 +1,27 @@
+fileFormatVersion: 2
+guid: 47afe0f44a1b1a64b80818931e4dec8b
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Utility/UnityDenoiserPlugin/OpenImageDenoise_device_cuda.dll.meta
+++ b/TrueTrace/Resources/Utility/UnityDenoiserPlugin/OpenImageDenoise_device_cuda.dll.meta
@@ -1,0 +1,27 @@
+fileFormatVersion: 2
+guid: 611d95ad58675594fa92cf36c4cbdf73
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Utility/UnityDenoiserPlugin/UnityDenoiserPlugin.cs.meta
+++ b/TrueTrace/Resources/Utility/UnityDenoiserPlugin/UnityDenoiserPlugin.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: faf5c9a8af0b1364eabc5cc77ee03fc0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Utility/UnityDenoiserPlugin/UnityDenoiserPlugin.dll.meta
+++ b/TrueTrace/Resources/Utility/UnityDenoiserPlugin/UnityDenoiserPlugin.dll.meta
@@ -1,0 +1,27 @@
+fileFormatVersion: 2
+guid: 65f4a970230db554fb62c8d4d3287b96
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Utility/Water.meta
+++ b/TrueTrace/Resources/Utility/Water.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5ea531f872f3d1346a910ba9b74d91f4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Utility/Water/WaveShaderV2.compute.meta
+++ b/TrueTrace/Resources/Utility/Water/WaveShaderV2.compute.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2473bc377bc7e654d9a4938a16386bb2
+ComputeShaderImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Utility/Water/WaveV2.cs.meta
+++ b/TrueTrace/Resources/Utility/Water/WaveV2.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d8f274ad151dca14686a78c6fb5a6acf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Utility/Water/WaveV2Voxelize.shader.meta
+++ b/TrueTrace/Resources/Utility/Water/WaveV2Voxelize.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: b99e214acb619504683b19ea3f837708
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/TrueTrace.asmdef.meta
+++ b/TrueTrace/TrueTrace.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a0c582bf036553c45ad7839077e3a14f
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This PR makes it possible to use the TrueTrace repository as a git submodule.

Changes this PR introduces are:

- Added meta files to properly manage asmdef references
- Added a Pathfinder class to find and cache the TrueTrace Resources folder dynamically