### PR TITLE
Make TrueTrace work as a git submodule again

### DIFF
--- a/TrueTrace/Editor/PathTracerSettings.cs
+++ b/TrueTrace/Editor/PathTracerSettings.cs
@@ -104,9 +104,11 @@ namespace TrueTrace {
          [SerializeField] public bool MatChangeResetsAccum = false;
 
 
-         public void SetGlobalDefines(string DefineToSet, bool SetValue) {
-            if(File.Exists(Application.dataPath + "/TrueTrace/Resources/GlobalDefines.cginc")) {
-               string[] GlobalDefines = System.IO.File.ReadAllLines(Application.dataPath + "/TrueTrace/Resources/GlobalDefines.cginc");
+         public void SetGlobalDefines(string DefineToSet, bool SetValue)
+         {
+            var globalDefinesPath = TTPathFinder.GetGlobalDefinesPath();
+            if(File.Exists(globalDefinesPath)) {
+               string[] GlobalDefines = System.IO.File.ReadAllLines(globalDefinesPath);
                int Index = -1;
                for(int i = 0; i < GlobalDefines.Length; i++) {
                   if(GlobalDefines[i].Equals("//END OF DEFINES")) break;
@@ -127,7 +129,7 @@ namespace TrueTrace {
                   GlobalDefines[Index] = GlobalDefines[Index].Replace("// ", "");
                   if(!SetValue) GlobalDefines[Index] = "// " + GlobalDefines[Index];
 
-                  System.IO.File.WriteAllLines(Application.dataPath + "/TrueTrace/Resources/GlobalDefines.cginc", GlobalDefines);
+                  System.IO.File.WriteAllLines(globalDefinesPath, GlobalDefines);
                   AssetDatabase.Refresh();
                }
             } else {Debug.Log("No GlobalDefinesFile");}
@@ -1000,7 +1002,8 @@ Toolbar toolbar;
          MatShader.IsCutout = CutoutToggle.value;
          MatShader.UsesSmoothness = SmoothnessToggle.value;
          AssetManager.data.Material[Index] = MatShader;
-         using(StreamWriter writer = new StreamWriter(Application.dataPath + "/TrueTrace/Resources/Utility/MaterialMappings.xml")) {
+         var materialMappingsPath = TTPathFinder.GetMaterialMappingsPath();
+         using(StreamWriter writer = new StreamWriter(materialMappingsPath)) {
             var serializer = new XmlSerializer(typeof(Materials));
             serializer.Serialize(writer.BaseStream, AssetManager.data);
             AssetDatabase.Refresh();
@@ -1098,7 +1101,8 @@ Toolbar toolbar;
          if(Index == -1) {
             if(Assets != null && Assets.NeedsToUpdateXML) {
                Assets.AddMaterial(shader);
-               using(StreamWriter writer = new StreamWriter(Application.dataPath + "/TrueTrace/Resources/Utility/MaterialMappings.xml")) {
+               var materialMappingsPath = TTPathFinder.GetMaterialMappingsPath();
+               using(StreamWriter writer = new StreamWriter(materialMappingsPath)) {
                   var serializer = new XmlSerializer(typeof(Materials));
                   serializer.Serialize(writer.BaseStream, AssetManager.data);
                   AssetDatabase.Refresh();
@@ -2327,7 +2331,8 @@ void AddResolution(int width, int height, string label)
                          }
                       }
                   } catch(System.Exception e) {HasNoMore = true;};
-                  using(StreamWriter writer = new StreamWriter(Application.dataPath + "/TrueTrace/Resources/Utility/SaveFile.xml")) {
+                  var saveFilePath = TTPathFinder.GetSaveFilePath();
+                  using(StreamWriter writer = new StreamWriter(saveFilePath)) {
                       var serializer = new XmlSerializer(typeof(RayObjs));
                       serializer.Serialize(writer.BaseStream, new RayObjs());
                       UnityEditor.AssetDatabase.Refresh();
@@ -2340,7 +2345,8 @@ void AddResolution(int width, int height, string label)
             if(RayMaster != null) SampleCountField.value = RayMaster.SampleCount;
             
             if(Assets != null && Assets.NeedsToUpdateXML) {
-                using(StreamWriter writer = new StreamWriter(Application.dataPath + "/TrueTrace/Resources/Utility/MaterialMappings.xml")) {
+               var materialMappingsPath = TTPathFinder.GetMaterialMappingsPath();
+               using(StreamWriter writer = new StreamWriter(materialMappingsPath)) {
                   var serializer = new XmlSerializer(typeof(Materials));
                   serializer.Serialize(writer.BaseStream, AssetManager.data);
                }

--- a/TrueTrace/Editor/RayTracingObjectEditor.cs
+++ b/TrueTrace/Editor/RayTracingObjectEditor.cs
@@ -88,7 +88,8 @@ namespace TrueTrace {
                 if(CopyIndex != -1) PresetRays.RayObj[CopyIndex] = TempRay;
                 else PresetRays.RayObj.Add(TempRay);
 
-                using(StreamWriter writer = new StreamWriter(Application.dataPath + "/TrueTrace/Resources/Utility/MaterialPresets.xml")) {
+                var materialPresetsPath = TTPathFinder.GetMaterialPresetsPath();
+                using(StreamWriter writer = new StreamWriter(materialPresetsPath)) {
                     var serializer = new XmlSerializer(typeof(RayObjs));
                     serializer.Serialize(writer.BaseStream, PresetRays);
                     UnityEditor.AssetDatabase.Refresh();
@@ -130,7 +131,8 @@ namespace TrueTrace {
                     if(GUILayout.Button(PresetRays.RayObj[i].MatName)) {CallEditorFunction(PresetRays.RayObj[i]); this.editorWindow.Close();}
                     if(GUILayout.Button("Delete")) {
                         PresetRays.RayObj.RemoveAt(i);
-                        using(StreamWriter writer = new StreamWriter(Application.dataPath + "/TrueTrace/Resources/Utility/MaterialPresets.xml")) {
+                        var materialPresetsPath = TTPathFinder.GetMaterialPresetsPath();
+                        using(StreamWriter writer = new StreamWriter(materialPresetsPath)) {
                             var serializer = new XmlSerializer(typeof(RayObjs));
                             serializer.Serialize(writer.BaseStream, PresetRays);
                             UnityEditor.AssetDatabase.Refresh();
@@ -262,8 +264,9 @@ namespace TrueTrace {
                 };
                 if(CopyIndex != -1) PresetRays.RayObj[CopyIndex] = TempRay;
                 else PresetRays.RayObj.Add(TempRay);
-
-                using(StreamWriter writer = new StreamWriter(Application.dataPath + "/TrueTrace/Resources/Utility/MaterialPresets.xml")) {
+                
+                var materialPresetsPath = TTPathFinder.GetMaterialPresetsPath();
+                using(StreamWriter writer = new StreamWriter(materialPresetsPath)) {
                     var serializer = new XmlSerializer(typeof(RayObjs));
                     serializer.Serialize(writer.BaseStream, PresetRays);
                     UnityEditor.AssetDatabase.Refresh();

--- a/TrueTrace/Editor/RenderingPipelineDefines.cs
+++ b/TrueTrace/Editor/RenderingPipelineDefines.cs
@@ -1,6 +1,7 @@
 #if UNITY_EDITOR
 using System.Collections.Generic;
 using System.Linq;
+using TrueTrace;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.Rendering;
@@ -21,9 +22,11 @@ public class RenderingPipelineDefines
         UpdateDefines();
     }
 
-    static void SetGlobalDefines(string DefineToSet, bool SetValue) {
-        if(System.IO.File.Exists(Application.dataPath + "/TrueTrace/Resources/GlobalDefines.cginc")) {
-            string[] GlobalDefines = System.IO.File.ReadAllLines(Application.dataPath + "/TrueTrace/Resources/GlobalDefines.cginc");
+    static void SetGlobalDefines(string DefineToSet, bool SetValue)
+    {
+        var globalDefinesPath = TTPathFinder.GetGlobalDefinesPath();
+        if(System.IO.File.Exists(globalDefinesPath)) {
+            string[] GlobalDefines = System.IO.File.ReadAllLines(globalDefinesPath);
             int Index = -1;
             for(int i = 0; i < GlobalDefines.Length; i++) {
                 if(GlobalDefines[i].Equals("//END OF DEFINES")) break;
@@ -41,7 +44,7 @@ public class RenderingPipelineDefines
             GlobalDefines[Index] = GlobalDefines[Index].Replace("// ", "");
             if(!SetValue) GlobalDefines[Index] = "// " + GlobalDefines[Index];
 
-            System.IO.File.WriteAllLines(Application.dataPath + "/TrueTrace/Resources/GlobalDefines.cginc", GlobalDefines);
+            System.IO.File.WriteAllLines(globalDefinesPath, GlobalDefines);
             AssetDatabase.Refresh();
         } else {Debug.Log("No GlobalDefinesFile");}
     }

--- a/TrueTrace/Resources/RayTracingMaster.cs
+++ b/TrueTrace/Resources/RayTracingMaster.cs
@@ -317,7 +317,8 @@ namespace TrueTrace {
 
         void OnDestroy() {
             #if UNITY_EDITOR
-                using(StreamWriter writer = new StreamWriter(Application.dataPath + "/TrueTrace/Resources/Utility/SaveFile.xml")) {
+                var saveFilePath = TTPathFinder.GetSaveFilePath();
+                using(StreamWriter writer = new StreamWriter(saveFilePath)) {
                     var serializer = new XmlSerializer(typeof(RayObjs));
                     serializer.Serialize(writer.BaseStream, raywrites);
                     UnityEditor.AssetDatabase.Refresh();

--- a/TrueTrace/Resources/Utility/TTPathfinder.cs
+++ b/TrueTrace/Resources/Utility/TTPathfinder.cs
@@ -1,0 +1,47 @@
+using System;
+using System.IO;
+using UnityEngine;
+
+namespace TrueTrace
+{
+    public static class TTPathFinder
+    {
+        private static string baseResourcePath;
+
+        public static string GetResourcePath()
+        {
+            if (!string.IsNullOrEmpty(baseResourcePath))
+                return NormalizePath(baseResourcePath);
+
+            // Use more precise search parameters to reduce overhead and potential errors
+            var searchPattern = "Resources";
+            var directories = Directory.GetDirectories(Application.dataPath, searchPattern, SearchOption.AllDirectories);
+
+            foreach (var dir in directories)
+            {
+                string normalizedDir = NormalizePath(dir);
+                
+                if (normalizedDir.EndsWith("/TrueTrace/Resources"))
+                {
+                    baseResourcePath = normalizedDir;
+                    return normalizedDir;
+                }
+            }
+
+            Debug.LogError("Resource path not found.");  // Use Error logging for better visibility
+            throw new Exception("Resource path not found.");
+        }
+        
+        private static string NormalizePath(string path)
+        {
+            // Always use forward slashes to prevent platform-specific issues
+            return Path.Combine(path).Replace('\\', '/');
+        }
+
+        // Ensure all paths returned from these methods are normalized
+        public static string GetSaveFilePath() => NormalizePath(Path.Combine(GetResourcePath(), "Utility/SaveFile.xml"));
+        public static string GetGlobalDefinesPath() => NormalizePath(Path.Combine(GetResourcePath(), "GlobalDefines.cginc"));
+        public static string GetMaterialPresetsPath() => NormalizePath(Path.Combine(GetResourcePath(), "Utility/MaterialPresets.xml"));
+        public static string GetMaterialMappingsPath() => NormalizePath(Path.Combine(GetResourcePath(), "Utility/MaterialMappings.xml"));
+    }
+}

--- a/TrueTrace/Resources/Utility/TTPathfinder.cs.meta
+++ b/TrueTrace/Resources/Utility/TTPathfinder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b50973ee3838cfe45884f3827067a3f9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This PR reenables git submodule usage after the recent QoL update.

Changes introduced:

	- Use the TTPathfinder class to find TrueTrace references instead of hardcoded folder paths.