### PR TITLE
Move TurnTableScriptEditor to Editor folder & Update editor .asmdef

### DIFF
--- a/TrueTrace/Editor/TrueTraceEditor.asmdef
+++ b/TrueTrace/Editor/TrueTraceEditor.asmdef
@@ -5,7 +5,9 @@
         "GUID:ed514bd980ff3ea46904db26e115c21d",
         "GUID:457756d89b35d2941b3e7b37b4ece6f1"
     ],
-    "includePlatforms": [],
+    "includePlatforms": [
+        "Editor"
+    ],
     "excludePlatforms": [],
     "allowUnsafeCode": true,
     "overrideReferences": false,

--- a/TrueTrace/Editor/TurntableScriptEditor.cs
+++ b/TrueTrace/Editor/TurntableScriptEditor.cs
@@ -1,0 +1,75 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace TrueTrace
+{
+    [CustomEditor(typeof(TurnTableScript))]
+    public class TurnTableScriptEditor : Editor
+    {
+        // Custom in-scene UI for when ExampleScript
+        // component is selected.
+        private float ttt;
+
+        private Vector3 GetTangent(float RadsAlong)
+        {
+            return new Vector3(Mathf.Sin(Mathf.Deg2Rad * RadsAlong), 0, Mathf.Cos(Mathf.Deg2Rad * RadsAlong))
+                .normalized;
+        }
+
+        private Vector3 GetToVector(float Yaw, float Pitch)
+        {
+            return new Vector3(Mathf.Cos(Mathf.Deg2Rad * Yaw) * Mathf.Cos(Mathf.Deg2Rad * Pitch),
+                Mathf.Sin(Mathf.Deg2Rad * Pitch), Mathf.Sin(Mathf.Deg2Rad * Yaw) * Mathf.Cos(Mathf.Deg2Rad * Pitch));
+        }
+
+        public void OnSceneGUI()
+        {
+            var t = target as TurnTableScript;
+            var tr = t.transform;
+            var pos = tr.position;
+            var ArcLength = 5.0f;
+            if (!t.Running)
+            {
+                ttt += Time.deltaTime;
+                EditorGUI.BeginChangeCheck();
+                if (t.CamSettings != null)
+                    for (var i = 0; i < t.CamSettings.Length; i++)
+                        if (t.CamSettings[i].Cam != null)
+                        {
+                            t.CamSettings[i].Center =
+                                Handles.PositionHandle(t.CamSettings[i].Center, Quaternion.identity);
+                            float yaw = 0;
+
+                            var Pos2 = t.CamSettings[i].Center +
+                                       GetToVector(yaw, t.CamSettings[i].Pitch) * t.CamSettings[i].Distance;
+                            t.CamSettings[i].Cam.transform.position = Pos2;
+
+
+                            var HorizSegments = t.CamSettings[i].HorizontalResolution;
+                            var Pos3 = new Vector3(t.CamSettings[i].Center.x, Pos2.y, t.CamSettings[i].Center.z);
+                            // Handles.DrawLine(Pos2, Pos2 + GetTangent(yaw), 0.01f);
+                            for (var i2 = 0; i2 < HorizSegments; i2++)
+                            {
+                                Handles.DrawWireArc(Pos3, Vector3.up,
+                                    GetTangent(90 + 360.0f / HorizSegments * i2 - ArcLength / 2.0f), ArcLength,
+                                    Vector3.Distance(Pos3, Pos2));
+                                var ToVector = GetToVector(90 + 360.0f / HorizSegments * i2, t.CamSettings[i].Pitch);
+                                t.CamSettings[i].Cam.transform.forward = ToVector;
+                                var Pos4 = t.CamSettings[i].Center + ToVector * t.CamSettings[i].Distance;
+                                Handles.ConeHandleCap(0, Pos4 - ToVector * 0.15f,
+                                    t.CamSettings[i].Cam.transform.rotation,
+                                    0.2f, EventType.Repaint);
+                                Handles.DrawDottedLine(t.CamSettings[i].Center, Pos4, 0.01f);
+                                // Handles.ConeHandleCap(0, t.CamSettings[i].Center - t.CamSettings[i].Cam.transform.forward * 0.1f, t.CamSettings[i].Cam.transform.rotation, 0.2f,  EventType.Repaint);
+                            }
+
+                            t.CamSettings[i].Cam.transform.forward = (t.CamSettings[i].Center - Pos2).normalized;
+                        }
+
+                if (EditorGUI.EndChangeCheck())
+                {
+                }
+            }
+        }
+    }
+}

--- a/TrueTrace/Editor/TurntableScriptEditor.cs.meta
+++ b/TrueTrace/Editor/TurntableScriptEditor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a9de36b8ba2616b44b53de57e9caa600

--- a/TrueTrace/Resources/Utility/Editor.meta
+++ b/TrueTrace/Resources/Utility/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3b5bbf62355e4d741a2f0a11a1cfdc2a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TrueTrace/Resources/Utility/TurnTableScript.cs
+++ b/TrueTrace/Resources/Utility/TurnTableScript.cs
@@ -99,7 +99,9 @@ namespace TrueTrace {
                             RayMaster.TossCamera(CamSettings[CurrentCamera].Cam);
                         } else {                            
                             Application.runInBackground = false;
+#if UNITY_EDITOR
                             EditorApplication.isPlaying = false;
+#endif
                         }
 
                     }
@@ -109,62 +111,6 @@ namespace TrueTrace {
         public void LateUpdate()
         {
             StartCoroutine(RecordFrame());
-        }
-
-    }
-
-    [CustomEditor(typeof(TurnTableScript))]
-    public class TurnTableScriptEditor : Editor
-    {
-        // Custom in-scene UI for when ExampleScript
-        // component is selected.
-        float ttt = 0;
-
-        Vector3 GetTangent(float RadsAlong) {
-            return (new Vector3(Mathf.Sin(Mathf.Deg2Rad * RadsAlong), 0, Mathf.Cos(Mathf.Deg2Rad * RadsAlong))).normalized;
-        }
-
-        Vector3 GetToVector(float Yaw, float Pitch) {
-            return new Vector3(Mathf.Cos(Mathf.Deg2Rad * Yaw) * Mathf.Cos(Mathf.Deg2Rad * Pitch), Mathf.Sin(Mathf.Deg2Rad * Pitch), Mathf.Sin(Mathf.Deg2Rad * Yaw) * Mathf.Cos(Mathf.Deg2Rad * Pitch));
-        }
-        public void OnSceneGUI()
-        {
-            var t = target as TurnTableScript;
-            var tr = t.transform;
-            var pos = tr.position;
-            float ArcLength = 5.0f;
-            if(!t.Running) {
-                ttt += Time.deltaTime;
-                EditorGUI.BeginChangeCheck();
-                if(t.CamSettings != null) {
-                    for(int i = 0; i < t.CamSettings.Length; i++) {
-                        if(t.CamSettings[i].Cam != null) {
-                            t.CamSettings[i].Center = Handles.PositionHandle(t.CamSettings[i].Center, Quaternion.identity);
-                            float yaw = 0;
-
-                            Vector3 Pos2 = t.CamSettings[i].Center + GetToVector(yaw, t.CamSettings[i].Pitch) * t.CamSettings[i].Distance;
-                            t.CamSettings[i].Cam.transform.position = Pos2;
-
-
-                            int HorizSegments = t.CamSettings[i].HorizontalResolution;
-                            Vector3 Pos3 = new Vector3(t.CamSettings[i].Center.x, Pos2.y, t.CamSettings[i].Center.z);
-                                // Handles.DrawLine(Pos2, Pos2 + GetTangent(yaw), 0.01f);
-                            for(int i2 = 0; i2 < HorizSegments; i2++) {
-                                Handles.DrawWireArc(Pos3, Vector3.up, GetTangent(90 + 360.0f / (float)HorizSegments * (float)i2 - (ArcLength / 2.0f)), ArcLength, Vector3.Distance(Pos3, Pos2));
-                                Vector3 ToVector = GetToVector(90 + 360.0f / (float)HorizSegments * (float)i2, t.CamSettings[i].Pitch);
-                                t.CamSettings[i].Cam.transform.forward = ToVector;
-                                Vector3 Pos4 = t.CamSettings[i].Center + ToVector * t.CamSettings[i].Distance;
-                                Handles.ConeHandleCap(0, Pos4 - ToVector * 0.15f, t.CamSettings[i].Cam.transform.rotation, 0.2f,  EventType.Repaint);
-                                Handles.DrawDottedLine(t.CamSettings[i].Center, Pos4, 0.01f);
-                                // Handles.ConeHandleCap(0, t.CamSettings[i].Center - t.CamSettings[i].Cam.transform.forward * 0.1f, t.CamSettings[i].Cam.transform.rotation, 0.2f,  EventType.Repaint);
-                            }
-
-                            t.CamSettings[i].Cam.transform.forward = (t.CamSettings[i].Center - Pos2).normalized;
-                        }
-                    }
-                }
-                if (EditorGUI.EndChangeCheck()) {}
-            }
         }
     }
 }


### PR DESCRIPTION
This PR moves the editor code of the turntable script to it's own file in an editor folder.
Also updates TrueTraceEditor.asmdef to only be included in editor.